### PR TITLE
Fix paths to built package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remla23-team18",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remla23-team18",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "devDependencies": {
         "@types/jest": "^29.5.1",
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@remla23-team18/lib",
   "version": "1.0.1",
   "description": "A version-aware library",
-  "author": "",
+  "author": "Reuben Gardos Reid, Yuchuan Fu, Mehul Bhuradia",
   "license": "",
   "homepage": "https://github.com/remla23-team18/lib#readme",
   "repository": {
@@ -12,8 +12,8 @@
   "bugs": {
     "url": "https://github.com/remla23-team18/lib/issues"
   },
-  "main": "lib/index.ts",
-  "types": "lib/index.d.ts",
+  "main": "lib/src/index.js",
+  "types": "lib/src/index.d.ts",
   "scripts": {
     "test": "jest --config jestconfig.json",
     "format": "prettier --write \"src/**/*\" \"./*.json\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remla23-team18/lib",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A version-aware library",
   "author": "Reuben Gardos Reid, Yuchuan Fu, Mehul Bhuradia",
   "license": "",


### PR DESCRIPTION
It was not possible to load/use the built/released package because the paths
to the "entry-point" of the package were not defined correctly.

This is now fixed, and it is verified to be working correctly.
